### PR TITLE
Fixed gitignore and typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
 /CMakeFiles
-tile_editor.cpp
-cmake_install.cmake
-Makefile
-CMakeCache.txt
-engine
+/build

--- a/main.cpp
+++ b/main.cpp
@@ -2,7 +2,7 @@
 #include "raylib.h"
 #include "include/engine.hpp"
 #include "include/entity.hpp"
-#include "includescreen.hpp"
+#include "include/screen.hpp"
 #define SPEED 500
 void CheckMovement(Entity & Player) {
 	bool moveUp = IsKeyDown(KEY_W) || IsKeyDown(KEY_UP);


### PR DESCRIPTION
now on linux:
`mkdir build && cd build && cmake . && make`